### PR TITLE
Changed read_gbq dialect default to 'standard'

### DIFF
--- a/pandas_gbq/gbq.py
+++ b/pandas_gbq/gbq.py
@@ -152,7 +152,7 @@ class GbqConnector(object):
 
     def __init__(self, project_id, reauth=False,
                  private_key=None, auth_local_webserver=False,
-                 dialect='legacy', location=None):
+                 dialect='standard', location=None):
         from google.api_core.exceptions import GoogleAPIError
         from google.api_core.exceptions import ClientError
         from pandas_gbq import auth


### PR DESCRIPTION
As of today, Google's bigquery web UI uses Standard as the default dialect.