### PR TITLE
Updated docstring

### DIFF
--- a/pandas_gbq/read_gbq
+++ b/pandas_gbq/read_gbq
@@ -152,7 +152,7 @@ class GbqConnector(object):
 
     def __init__(self, project_id, reauth=False,
                  private_key=None, auth_local_webserver=False,
-                 dialect='legacy', location=None):
+                 dialect='standard', location=None):
         from google.api_core.exceptions import GoogleAPIError
         from google.api_core.exceptions import ClientError
         from pandas_gbq import auth
@@ -514,7 +514,7 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
             http://google-auth-oauthlib.readthedocs.io/en/latest/reference/google_auth_oauthlib.flow.html#google_auth_oauthlib.flow.InstalledAppFlow.run_console
 
         .. versionadded:: 0.2.0
-    dialect : str, default 'legacy'
+    dialect : str, default 'standard'
         SQL syntax dialect to use. Value can be one of:
 
         ``'legacy'``


### PR DESCRIPTION
As of today, Google's bigquery web UI uses Standard as the default dialect.